### PR TITLE
Fix bug resulting in wrong bitrate report

### DIFF
--- a/wmediumd/wmediumd.c
+++ b/wmediumd/wmediumd.c
@@ -676,7 +676,14 @@ void deliver_frame(struct wmediumd *ctx, struct frame *frame)
 					frame->sender->index, frame->duration,
 					frame->signal))
 					continue;
+				// use the value that is last in list.
 				rate_idx = frame->tx_rates[0].idx;
+				for(int i = 0; i < frame->tx_rates_count; i++) {
+					if(frame->tx_rates[i].idx == -1) {
+						break;
+					}
+					rate_idx = frame->tx_rates[i].idx;
+				}
 				send_cloned_frame_msg(ctx, station,
 						      frame->data,
 						      frame->data_len,


### PR DESCRIPTION
This PR fixes a bug which causes `wmediumd` to report the wrong bitrate to the message receiver. 

During emulation with mininet-wifi, it came to our attention that `iw` reported incorrect bitrates. Investigation into this problem yielded that `wmediumd` reported the first `tx_rate` instead of the last (valid) one.
