### PR TITLE
Fix Nakagami-m Mobility Test and Improve Linux/WSL2 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,19 +180,19 @@ model :
         ( 10.0,  0.0, 0.0)   /* Node 4 - East */
     );
 
-    /* Mobility: meters per MOVE_INTERVAL (1s) */
+    /* Mobility: 1 m/s (Direction values are in meters per 3s update interval) */
     directions = (
-        (-2.0, 0.0),  /* Node 1 flies West at 2m/s */
-        ( 0.0, 0.0),  /* Node 2 static */
-        ( 0.0, 0.0),  /* Node 3 static */
-        ( 2.0, 0.0)   /* Node 4 flies East at 2m/s */
+        (-3.0, 0.0),  /* Node 1 flies West at 1 m/s */
+        ( 0.0, 0.0),  /* Node 2 static              */
+        ( 0.0, 0.0),  /* Node 3 static              */
+        ( 3.0, 0.0)   /* Node 4 flies East at 1 m/s */
     );
 
     tx_powers = (20.0, 20.0, 20.0, 20.0);
     model_name = "nakagami";
-    m = 2.5;                   /* Moderate LoS */
-    path_loss_exp = 2.5;       
-    xg = 0.0;                  
+    m = 1.5;             /* Partial LoS (Typical UAV fading) Deep-fade probability ~15% */
+    path_loss_exp = 4.0; /* Dense urban; SNR ~39 dB (t=0s) -> ~17 dB (t=30s)            */
+    xg = 0.0;
 };
 ```
 

--- a/tests/plot_nakagami_test.py
+++ b/tests/plot_nakagami_test.py
@@ -1,6 +1,6 @@
 # Author: Bruno Fernandes <bruno.fernandes@tum.de>
-# Last update: 22.03.2026
-# 
+# Last update: 10.05.2026
+#
 # For further details please check /wmediumd/tests/test_nakagami_mobility.sh
 # This plot_nakagami_test.py is for the sole purpose of printing out the log files after the test.
 
@@ -13,26 +13,26 @@ IPS = ["10.10.10.11", "10.10.10.12", "10.10.10.13", "10.10.10.14"]
 
 def parse_iperf(filename):
     intervals, throughput = [], []
-    current_unit = "Mbits/sec" # Default
-    
-    pattern = re.compile(r'\]\s+(\d+\.\d+)-\s*(\d+\.\d+)\s+sec\s+\d+\.?\d*\s+[MKG]Bytes\s+(\d+\.?\d*)\s+([MKG]bits)/sec')
-    
+    unit = "Mbits/sec"
+
+    pattern = re.compile(r'\]\s+(\d+\.\d+)-\s*(\d+\.\d+)\s+sec\s+[\d.]+\s+[KMG]Bytes\s+([\d.]+)\s+([KM]bits)/sec')
+
     try:
         with open(filename, 'r') as f:
             for line in f:
                 # Skip the summary line at the very end
                 if "0.0000-" in line and float(line.split('-')[1].split()[0]) > 29.5:
-                    if len(intervals) > 5: continue 
-                
+                    if len(intervals) > 5: continue
+
                 match = pattern.search(line)
                 if match:
                     intervals.append(float(match.group(2)))
                     throughput.append(float(match.group(3)))
-                    current_unit = f"{match.group(4)}/sec" # Detect Mbits or Gbits
+                    unit = f"{match.group(4)}/sec"
     except FileNotFoundError:
         print("Log file not found.")
-    
-    return intervals, throughput, current_unit
+
+    return intervals, throughput, unit
 
 i_time, i_bw, i_unit = parse_iperf('iperf_client.log')
 
@@ -49,19 +49,19 @@ ax_perf = plt.subplot(212)
 def animate(i):
     ax_topo.clear()
     ax_perf.clear()
-    
+
     t = i_time[i]
-    
-    # Coordinates (Diamond moves based on 2m/s velocity)
-    n1 = [-10 - (2*t), 0]
+
+    # Coordinates (Diamond moves based on 1m/s velocity)
+    n1 = [-10 - t, 0]
     n2 = [0, 5]
     n3 = [0, -5]
-    n4 = [10 + (2*t), 0]
+    n4 = [10 + t, 0]
     pos = np.array([n1, n2, n3, n4])
-    
+
     # Plot Nodes
     ax_topo.scatter(pos[:,0], pos[:,1], s=200, c=['#ff7f0e', '#1f77b4', '#1f77b4', '#2ca02c'])
-    
+
     # Draw Mesh Connections
     links = [[0,1], [0,2], [1,3], [2,3]]
     for l in links:
@@ -72,8 +72,8 @@ def animate(i):
         label = f"Node {j+1}\n({IPS[j]})"
         ax_topo.annotate(label, (pos[j,0], pos[j,1]), textcoords="offset points", xytext=(0,10), ha='center')
 
-    ax_topo.set_title(f"Simulation Topology | Time: {t:.1f}s | Distance 1-4: {20+(4*t):.1f}m")
-    ax_topo.set_xlim(-85, 85)
+    ax_topo.set_title(f"Simulation Topology | Time: {t:.1f}s | Distance 1-4: {20+(2*t):.1f}m")
+    ax_topo.set_xlim(-50, 50)
     ax_topo.set_ylim(-15, 15)
     ax_topo.set_xlabel("X (meters)")
     ax_topo.grid(True, alpha=0.2)
@@ -81,12 +81,12 @@ def animate(i):
     # Plot Performance (Dynamic Scale)
     ax_perf.plot(i_time[:i+1], i_bw[:i+1], color='green', linewidth=2, marker='o', markersize=4)
     ax_perf.set_xlim(0, 31)
-    
+
     # Dynamic Y-Limit: Adds 20% padding to the highest recorded value
     y_limit = max(i_bw) * 1.2 if i_bw else 40
     ax_perf.set_ylim(0, y_limit)
-    
-    ax_perf.set_title(f"Throughput vs. Time (Nakagami m=2.5)")
+
+    ax_perf.set_title(f"Throughput vs. Time (Nakagami m=1.5)")
     ax_perf.set_ylabel(i_unit) # Dynamic Label
     ax_perf.set_xlabel("Seconds")
     ax_perf.grid(True, linestyle=':')

--- a/tests/test_nakagami_mobility.sh
+++ b/tests/test_nakagami_mobility.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Author: Bruno Fernandes <bruno.fernandes@tum.de>
-# Last update: 22.03.2026
+# Last update: 10.05.2026
 
 # Topology: 4 nodes starting in a diamond, Node 1 and 4 flying apart.
 # Node 1 (10.10.10.11) <---> Node 4 (10.10.10.14)
@@ -12,34 +12,94 @@
 #  |       |       |
 #  + ---- [3] ---- +
 #
+# This test validates the Nakagami-m fading model behaves in as expected under mobility.
+# The iperf throughput trace serves as the observable stochastic fluctuations driven by
+# fading, running on top of the deterministic SNR decline as Node 1 and Node 4 fly apart,
+# confirm that the channel model is active and working correctly.
+#
 # Understanding the m Parameter for your experiment with nakagami-m model
-# When you run your tests, here is a short table on how you should tune that m value in the config file to represent different scenarios:
+# When you run your tests, here is a short table on how you should tune that m value in
+# the config file to represent different scenarios:
+#
 # Environment       | m Value        | Description
 # Heavy Obstruction | 0.5 <= m < 1.0 | Severe fading, worse than Rayleigh. High packet loss.
 # No Line-of-Sight  | m = 1.0        | Pure Rayleigh fading (classic urban/forest ground scenario).
 # Partial LoS       | m = 1.5 - 3.0  | Typical for UAVs, mostly clear skies but some banking/antenna tilt issues.
 # Strong LoS        | m > 5.0        | Clear Line of Sight between UAVs. Very stable signal.
+#
+# Quick reminder on the path_loss_exp for reference:
+# 2.0 - 2.5 | Free space / outdoor LoS
+# 2.5 - 3.5 | Suburban / light obstruction
+# 3.5 - 4.0 | Dense urban  (recommended range for visible fading without link collapse)
+# 4.5+      | Heavy obstruction (risks sustained TCP stall across a 30s test)
+#
+# MOVE_INTERVAL = 3s (wmediumd constant). Direction values are meters per interval (e.g. 3.0 = 1 m/s).
 
 num_nodes=4
 subnet="10.10.10"
 macfmt="02:00:00:00:%02x:00"
 
+# --- PREREQUISITE CHECK ---
 if [[ $UID -ne 0 ]]; then
     echo "Must be run as root! (sudo)"
     exit 1
 fi
 
+# --- CLEANUP FUNCTION IN CASE OF INTERRUPTION ---
+_cleanup() {
+    echo "Interrupted, cleaning up..."
+    kill $PING_PID $SERVER_PID $CLIENT_PID $WMEDIUMD_PID 2>/dev/null
+    sleep 1
+    killall -9 iperf wmediumd 2>/dev/null
+    for ns in $(ip netns list | awk '{print $1}'); do
+        ip netns del "$ns" 2>/dev/null
+    done
+    modprobe -r mac80211_hwsim 2>/dev/null
+}
+trap _cleanup INT TERM HUP
+
 # --- ENSURE THE STAGE IS CLEAR ---
-echo "Cleaning up..."
+echo "Preparing the environment for testing..."
 killall -9 wmediumd xterm iperf 2>/dev/null
-for i in $(seq 1 $num_nodes); do ip netns del "node$i" 2>/dev/null; done
+# Remove any 'zombie' namespaces
+for ns in $(ip netns list | awk '{print $1}'); do
+    ip netns exec "$ns" ip link set lo down 2>/dev/null
+    ip netns del "$ns" 2>/dev/null
+done
+# Specific to clean up the directory where WSL2 locks namespaces
+rm -rf /var/run/netns/* 2>/dev/null
+
+# Reload the wireless stack so each run starts from a clean kernel state.
 modprobe -r mac80211_hwsim 2>/dev/null
-sleep 1
+modprobe -r mac80211 2>/dev/null
+modprobe -r cfg80211 2>/dev/null
+sleep 2
+
+echo "Waiting for virtual radios to initialize..."
+modprobe cfg80211
 modprobe mac80211_hwsim radios=$num_nodes
-sleep 1
+sleep 2
+timeout=10
+count=0
+while ! iw dev | grep -q "wlan3"; do
+    sleep 0.5
+    count=$((count+1))
+    if [ $count -ge $((timeout*2)) ]; then
+        echo "Error: Radios failed to initialize after ${timeout}s"
+        exit 1
+    fi
+done
+
+# Ensure interfaces are in a known state (usually DOWN for wmediumd)
+ip link set wlan0 down
+ip link set wlan1 down
+ip link set wlan2 down
+ip link set wlan3 down
+
+echo "Radios ready."
 
 # --- GENERATE NAKAGAMI CONFIG FILE WITH MOVEMENT ---
-cat <<__EOM > nakagami_mobility_test.cfg
+cat <<__EOM > nakagami_mobility.cfg
 ifaces :
 {
     ids = [
@@ -54,74 +114,55 @@ model :
 {
     type = "path_loss";
     positions = (
-        (-10.0,  0.0, 0.0),  /* Node 1 - West */
+        (-10.0,  0.0, 0.0),  /* Node 1 - West  */
         (  0.0,  5.0, 0.0),  /* Node 2 - North */
         (  0.0, -5.0, 0.0),  /* Node 3 - South */
-        ( 10.0,  0.0, 0.0)   /* Node 4 - East */
+        ( 10.0,  0.0, 0.0)   /* Node 4 - East  */
     );
 
-    /* Mobility: meters per MOVE_INTERVAL (1s) */
+    /* Mobility: 1 m/s. Multi-hop distance increases from ~11 m to ~40 m over 30 s */
     directions = (
-        (-2.0, 0.0),  /* Node 1 flies West at 2m/s */
-        ( 0.0, 0.0),  /* Node 2 static */
-        ( 0.0, 0.0),  /* Node 3 static */
-        ( 2.0, 0.0)   /* Node 4 flies East at 2m/s */
+        (-3.0, 0.0),  /* Node 1 flies West  at 1 m/s */
+        ( 0.0, 0.0),  /* Node 2 static               */
+        ( 0.0, 0.0),  /* Node 3 static               */
+        ( 3.0, 0.0)   /* Node 4 flies East  at 1 m/s */
     );
 
     tx_powers = (20.0, 20.0, 20.0, 20.0);
     model_name = "nakagami";
-    m = 0.5;                   /* Moderate LoS */
-    path_loss_exp = 2.5;       
-    xg = 0.0;                  
+    m = 1.5;             /* Partial LoS (Typical UAV fading) Deep-fade probability ~15% */
+    path_loss_exp = 4.0; /* Dense urban; SNR ~39 dB (t=0s) -> ~17 dB (t=30s)            */
+    xg = 0.0;
 };
 __EOM
 
-# --- NAMESPACE & PHY SETUP ---
-echo "Waiting for hwsim to initialize radios..."
-sleep 2 
 
+# Force regulatory domain so the 20 dBm TX power configured above is permitted on 2.4 GHz.
+iw reg set US
+sleep 1
+
+# --- NAMESPACE & PHY SETUP (STEP 1) ---
+# Move each PHY to its namespace and configure the interface type, while keeping interfaces DOWN.
+echo "Setting up network namespaces..."
+declare -A NODE_DEVS
 for i in $(seq 1 $num_nodes); do
     NS="node$i"
-    IP="$subnet.$((10+i))"
     TARGET_MAC=$(printf $macfmt $((i-1)))
-    
-    # Wait for device availability in user space
+
     DEV=""
     while [ -z "$DEV" ]; do
         DEV=$(ip -br link show | grep -i "$TARGET_MAC" | awk '{print $1}')
         [ -z "$DEV" ] && sleep 0.5
     done
+    NODE_DEVS[$i]=$DEV
 
-    # Identify the phy interface
     PHY=$(iw dev "$DEV" info | grep wiphy | awk '{print "phy"$2}')
-
-    # Create namespace and move the phy to the new namespace
     ip netns add "$NS"
     ip link set "$DEV" down
     iw phy "$PHY" set netns name "$NS"
-
-    # Configuration
-    # The use of 'mesh point' instead of 'ibss' is to purposely handling peers better
+    # IBSS (Ad-Hoc): no L2 routing protocol overhead; compatible with WSL2.
     ip netns exec "$NS" ip link set lo up
-    ip netns exec "$NS" iw dev "$DEV" set type mesh
-    ip netns exec "$NS" ip link set "$DEV" up
-    ip netns exec "$NS" iw dev "$DEV" mesh join "MyMesh"
-    ip netns exec "$NS" ip addr add "$IP/24" dev "$DEV"
-
-    # Forcing ARP (Crucial for simulation)
-    # This ensures that Node 1 knows exactly where Node 4 is avoiding to search for it.
-    if [ $i -eq 1 ]; then
-        # Node 1 needs to know Node 4 MAC
-        TARGET_NODE_MAC=$(printf $macfmt 3)
-        ip netns exec "$NS" arp -s 10.10.10.14 $TARGET_NODE_MAC
-    fi
-    if [ $i -eq 4 ]; then
-        # Node 4 needs to know Node 1 MAC
-        TARGET_NODE_MAC=$(printf $macfmt 0)
-        ip netns exec "$NS" arp -s 10.10.10.11 $TARGET_NODE_MAC
-    fi
-
-    xterm -T "NODE $i ($IP)" -geometry 80x20+$(( (i-1)*300 ))+100 -e "ip netns exec $NS bash" &
+    ip netns exec "$NS" iw dev "$DEV" set type ibss
 done
 
 # --- STARTING SIMULATION ---
@@ -129,9 +170,78 @@ echo "Starting wmediumd in background..."
 ../wmediumd/wmediumd -c nakagami_mobility.cfg > wmediumd.log 2>&1 &
 WMEDIUMD_PID=$!
 
-sleep 2
+echo "Waiting for wmediumd to initialize..."
+timeout=10
+count=0
+while ! grep -q "Added station 3" wmediumd.log 2>/dev/null; do
+    sleep 0.1
+    count=$((count+1))
+    if ! kill -0 $WMEDIUMD_PID 2>/dev/null; then
+        echo "Error: wmediumd terminated unexpectedly"
+        cat wmediumd.log >&2
+        exit 1
+    fi
+    if [ $count -ge $((timeout*10)) ]; then
+        echo "Error: wmediumd failed to initialize after ${timeout}s"
+        exit 1
+    fi
+done
+
+# --- NAMESPACE & PHY SETUP (STEP 2) ---
+# Now that wmediumd is registered, we bring the interfaces up and join IBSS.
+echo "Joining IBSS network..."
+JOIN_PIDS=()
+for i in $(seq 1 $num_nodes); do
+    NS="node$i"
+    IP="$subnet.$((10+i))"
+    DEV=${NODE_DEVS[$i]}
+    BSSID="02:00:00:00:00:A1"
+
+    {
+        ip netns exec "$NS" ip link set "$DEV" up
+        # fixed-freq + fixed BSSID: keeps all nodes in one IBSS cell even when Node1/4 lose direct range.
+        # NOHT: 802.11g-only rates for predictable minstrel_ht behaviour, specially in WSL2.
+        ip netns exec "$NS" iw dev "$DEV" ibss join "Adhoc" 2412 NOHT fixed-freq $BSSID basic-rates 6,12,24 mcast-rate 6
+        ip netns exec "$NS" ip addr add "$IP/24" dev "$DEV"
+        ip netns exec "$NS" sysctl -wq net.ipv4.ip_forward=1
+    } &
+    JOIN_PIDS+=($!)
+
+    xterm -fn fixed -T "NODE $i ($IP)" -geometry 80x20+$(( (i-1)*300 ))+100 -e "ip netns exec $NS bash" &
+done
+for pid in "${JOIN_PIDS[@]}"; do wait "$pid"; done
+
+# --- WEIGHTED STATIC MULTI-HOP ROUTES ---
+# Static ARP entries prevent ARP broadcasts from failing across the multi-hop paths.
+echo "Configuring weighted routes (Node 1 <-> Node 2/3 <-> Node 4)..."
+MAC1=$(printf $macfmt 0)
+MAC2=$(printf $macfmt 1)
+MAC3=$(printf $macfmt 2)
+MAC4=$(printf $macfmt 3)
+
+# Node 1: Primary path via Node 2 (metric 100), Secondary via Node 3 (metric 200)
+ip netns exec node1 ip route add 10.10.10.14 via 10.10.10.12 metric 100
+ip netns exec node1 ip route add 10.10.10.14 via 10.10.10.13 metric 200
+
+# Node 4: Primary path via Node 2 (metric 100), Secondary via Node 3 (metric 200)
+ip netns exec node4 ip route add 10.10.10.11 via 10.10.10.12 metric 100
+ip netns exec node4 ip route add 10.10.10.11 via 10.10.10.13 metric 200
+
+# Neighbor ARPs (Direct links only)
+ip netns exec node1 arp -s 10.10.10.12 $MAC2
+ip netns exec node1 arp -s 10.10.10.13 $MAC3
+ip netns exec node2 arp -s 10.10.10.11 $MAC1
+ip netns exec node2 arp -s 10.10.10.14 $MAC4
+ip netns exec node3 arp -s 10.10.10.11 $MAC1
+ip netns exec node3 arp -s 10.10.10.14 $MAC4
+ip netns exec node4 arp -s 10.10.10.12 $MAC2
+ip netns exec node4 arp -s 10.10.10.13 $MAC3
 
 # --- AUTOMATED TEST BLOCK ---
+# The iperf measures sustained TCP throughput over 30s, capturing the combined
+# effect of increasing path loss and Nakagami fading on application layer performance.
+# The ping runs concurrently to track packet RTT and loss independently of TCP,
+# distinguishing between fading induced loss and TCP congestion backoff.
 echo "Launching Iperf Server on Node 4..."
 ip netns exec node4 iperf -s > iperf_server.log 2>&1 &
 SERVER_PID=$!
@@ -140,7 +250,6 @@ echo "Starting Ping and Iperf Client on Node 1..."
 ip netns exec node1 ping -i 0.5 10.10.10.14 > ping_results.log 2>&1 &
 PING_PID=$!
 
-# Run the client and capture its PID
 ip netns exec node1 iperf -c 10.10.10.14 -t 30 -i 1 > iperf_client.log 2>&1 &
 CLIENT_PID=$!
 
@@ -159,6 +268,10 @@ echo "Simulation finished. Closing log files..."
 kill $PING_PID $SERVER_PID $WMEDIUMD_PID 2>/dev/null
 sleep 1
 killall -9 iperf wmediumd 2>/dev/null
+for ns in $(ip netns list | awk '{print $1}'); do
+    ip netns del "$ns" 2>/dev/null
+done
+modprobe -r mac80211_hwsim 2>/dev/null
 
 echo "Launching visualization..."
 # Check if the log actually has data before plotting

--- a/wmediumd/config.c
+++ b/wmediumd/config.c
@@ -334,7 +334,7 @@ static void recalc_path_loss(struct wmediumd *ctx)
             signal = gains - path_loss - ctx->noise_threshold;
             if (ctx->nakagami_param != NULL) {
                 double gain = get_nakagami_gain_db(ctx->nakagami_param->m);
-                signal += (int)gain;
+                signal += (int)round(gain);
             }
             ctx->snr_matrix[ctx->num_stas * start + end] = signal;
             ctx->snr_matrix[ctx->num_stas * end + start] = signal;


### PR DESCRIPTION
This PR builds on [PR#16](https://github.com/ramonfontes/wmediumd/pull/16) and addresses several correctness issues found in the Nakagami-m test script, the visualization tool, and the core gain calculation. The changes were validated on both native Linux (kernel 6.8) and WSL2 (kernel 6.6), producing consistent and reproducible results on both platforms.

### Nakagami Gain Truncation Fix (`wmediumd/config.c`)
* The signal calculation applied the Nakagami gain as `signal += (int)gain`, which truncates toward zero. This systematically suppressed positive fading gains, biasing every channel sample toward attenuation and distorting the fading distribution.
* Fixed by replacing with `signal += (int)round(gain)`, which preserves the symmetric character of the Nakagami-m distribution.

### Test Script Overhaul (`tests/test_nakagami_mobility.sh`)
* **Reliability:** Replaced all fixed `sleep` calls with deterministic readiness checks, and polling is used for `wlan3` before loading `mac80211_hwsim`, and `wmediumd.log` for `"Added station 3"` before proceeding.
* **WSL2 Compatibility:** Added cleanup of `/var/run/netns/*` to remove namespace locks specific to WSL2, and a full wireless stack reload (`cfg80211, mac80211, mac80211_hwsim`) to guarantee a clean state between runs. More on [Building a Custom WSL2 Kernel for WiFi Simulation](https://gist.github.com/brunosfer/deec7b4d941b1afad83b597de9a0f3a3).
* **Mode switch:** Replaced `mesh` with `IBSS` (Ad-Hoc) mode. A fixed BSSID keeps all nodes in one cell even when Node 1 and Node 4 move out of direct range. The `NOHT` was added as it restricts the PHY to 802.11g rates for predictable rate adaptation behavior on both kernels.
* **Race condition fix:** Introduced a two step approach for namespace setup. The PHYs are moved to namespaces with interfaces kept DOWN, wmediumd is started and confirmed ready, then all 4 Nodes in IBSS join in parallel. This eliminates the race window that caused sporadic `(HWSIM_CMD_FRAME) EINVAL` errors in `wmediumd.log`.
* **Routing:** Added weighted static multi-hop routes (Node 1 to Node 2/3 to Node 4) with metric 100 and 200 as fail over, and full static ARP tables for all relay hops to prevent ARP broadcast failures and/or delays across the multi-hop path.
* **Corrected parameters:** Node velocity fixed from 2.0 (wrongly set 2 m/s) to 3.0 (correct for 1 m/s given the 3s `MOVE_INTERVAL`). More information on this, inside [wmediumd/tests/test_nakagami_mobility.sh](https://github.com/brunosfer/wmediumd/blob/mininet-wifi/tests/test_nakagami_mobility.sh) source code. Channel model updated to `m=1.5` (Partial LoS, typical for UAVs) and `path_loss_exp=4.0` (Dense Urban scenarios), which produces visible fading without causing sustained TCP stalls.
* Added `_cleanup()` trap for interruptions `INT/TERM/HUP` and namespace/module teardown in the post-processing block.

### Visualization Fix (`tests/plot_nakagami_test.py`)
* Fixed a stale variable name (`current_unit`) that would cause a crash whenever the log file would be missing.
* Corrected the node animation velocity, inter node distance label, and x-axis limits to match the updated 1 m/s movement and actual node travel range. Dynamic adaptation to Gbps was also removed due to limitation for WSL2 compatibility `NOHT`.

### README Update (`README.md`)
* Updated the Nakagami configuration example to match the current test defaults: `m=1.5`, `path_loss_exp=4.0`, direction values at 1 m/s with a clarifying note that values are meters per 3s update interval. More information on this, inside [wmediumd/tests/test_nakagami_mobility.sh](https://github.com/brunosfer/wmediumd/blob/mininet-wifi/tests/test_nakagami_mobility.sh) source code.