### PR TITLE
Add a configurable FTM ranging-error model

### DIFF
--- a/wmediumd/config.c
+++ b/wmediumd/config.c
@@ -654,6 +654,14 @@ int load_config(struct wmediumd *ctx, const char *file, const char *per_file, bo
 	float default_prob_value = 0.0;
 	bool *link_map = NULL;
 
+	/* PMSR/FTM ranging-error model defaults (off = exact geometry) */
+	ctx->pmsr_sigma_m = ctx->pmsr_nlos_prob = ctx->pmsr_nlos_bias_m = 0.0;
+	ctx->pmsr_crlb_alpha = 0.0;
+	ctx->pmsr_brms_ratio = 0.2887;   /* 1/sqrt(12): RMS bw of a flat spectrum */
+	ctx->pmsr_xsubi[0] = 1;
+	ctx->pmsr_xsubi[1] = 0;
+	ctx->pmsr_xsubi[2] = 0x330e;
+
 	if (full_dynamic) {
 		ctx->sta_array = malloc(0);
 		ctx->num_stas = 0;
@@ -765,6 +773,38 @@ int load_config(struct wmediumd *ctx, const char *file, const char *per_file, bo
 	} else {
 		ctx->get_fading_signal = get_no_fading_signal;
 		ctx->fading_coefficient = 0;
+	}
+
+	/*
+	 * PMSR/FTM two-state (LOS/NLOS) ranging-error model. Set these in the
+	 * model section (e.g. from a MATLAB-derived table per bandwidth and
+	 * environment); absent -> exact geometry.
+	 */
+	{
+		const config_setting_t *s;
+		int pmsr_seed = 1;
+
+		if ((s = config_lookup(cf, "model.pmsr_sigma_m")))
+			ctx->pmsr_sigma_m = config_setting_get_float(s);
+		if ((s = config_lookup(cf, "model.pmsr_nlos_prob")))
+			ctx->pmsr_nlos_prob = config_setting_get_float(s);
+		if ((s = config_lookup(cf, "model.pmsr_nlos_bias_m")))
+			ctx->pmsr_nlos_bias_m = config_setting_get_float(s);
+		if ((s = config_lookup(cf, "model.pmsr_crlb_alpha")))
+			ctx->pmsr_crlb_alpha = config_setting_get_float(s);
+		if ((s = config_lookup(cf, "model.pmsr_brms_ratio")))
+			ctx->pmsr_brms_ratio = config_setting_get_float(s);
+		if ((s = config_lookup(cf, "model.pmsr_seed"))) {
+			pmsr_seed = config_setting_get_int(s);
+			ctx->pmsr_xsubi[0] = (unsigned short)(pmsr_seed & 0xffff);
+			ctx->pmsr_xsubi[1] = (unsigned short)((pmsr_seed >> 16) & 0xffff);
+		}
+		if (ctx->pmsr_sigma_m > 0.0 || ctx->pmsr_nlos_prob > 0.0 ||
+		    ctx->pmsr_crlb_alpha > 0.0)
+			w_logf(ctx, LOG_NOTICE, "PMSR error model: sigma=%.3f m, "
+			       "crlb_alpha=%.2f, P(NLOS)=%.3f, bias=%.3f m, seed=%d\n",
+			       ctx->pmsr_sigma_m, ctx->pmsr_crlb_alpha,
+			       ctx->pmsr_nlos_prob, ctx->pmsr_nlos_bias_m, pmsr_seed);
 	}
 
 	ctx->move_stations = move_stations_donothing;

--- a/wmediumd/wmediumd.c
+++ b/wmediumd/wmediumd.c
@@ -348,6 +348,83 @@ static double sta_distance(struct station *a, struct station *b)
 }
 
 /*
+ * Channel bandwidth [Hz] carried by a PMSR peer request (its chandef); 0 if
+ * absent.
+ */
+static double pmsr_chan_bw_hz(struct nlattr *chan_attr)
+{
+	struct nlattr *ch[NL80211_ATTR_MAX + 1];
+
+	if (!chan_attr ||
+	    nla_parse_nested(ch, NL80211_ATTR_MAX, chan_attr, NULL) < 0 ||
+	    !ch[NL80211_ATTR_CHANNEL_WIDTH])
+		return 0.0;
+
+	switch (nla_get_u32(ch[NL80211_ATTR_CHANNEL_WIDTH])) {
+	case NL80211_CHAN_WIDTH_5:	return 5e6;
+	case NL80211_CHAN_WIDTH_10:	return 10e6;
+	case NL80211_CHAN_WIDTH_40:	return 40e6;
+	case NL80211_CHAN_WIDTH_80:
+	case NL80211_CHAN_WIDTH_80P80:	return 80e6;
+	case NL80211_CHAN_WIDTH_160:	return 160e6;
+	default:			return 20e6;
+	}
+}
+
+/*
+ * ToA Cramer-Rao lower bound for the LOS ranging jitter, from the requested
+ * bandwidth and the medium's own SNR:
+ *   sigma = alpha * c / (2*pi * B_rms * sqrt(2*SNR))
+ * Falls back to the fixed pmsr_sigma_m when bandwidth or SNR is unavailable.
+ */
+static double pmsr_crlb_sigma(struct wmediumd *ctx, struct station *a,
+			      struct station *b, struct nlattr **pa)
+{
+	double bw_hz = pmsr_chan_bw_hz(pa[NL80211_PMSR_PEER_ATTR_CHAN]);
+	double b_rms, snr_lin;
+
+	if (bw_hz <= 0.0 || !ctx->get_link_snr)
+		return ctx->pmsr_sigma_m;
+
+	snr_lin = pow(10.0, ctx->get_link_snr(ctx, a, b) / 10.0);
+	if (snr_lin < 1e-3)
+		snr_lin = 1e-3;
+	b_rms = ctx->pmsr_brms_ratio * bw_hz;
+
+	return ctx->pmsr_crlb_alpha * SPEED_OF_LIGHT_M_PER_S /
+	       (2.0 * M_PI * b_rms * sqrt(2.0 * snr_lin));
+}
+
+/*
+ * Two-state (LOS/NLOS) FTM ranging-error model. The clean geometric distance
+ * is perturbed by a zero-mean Gaussian LOS jitter of the given std dev and,
+ * with probability pmsr_nlos_prob, a positive exponential NLOS bias
+ * (reflections only lengthen the path). Private erand48 stream, reproducible.
+ */
+static double pmsr_apply_error(struct wmediumd *ctx, double dist, double sigma)
+{
+	double d = dist;
+
+	if (sigma > 0.0) {
+		double u1 = erand48(ctx->pmsr_xsubi);
+		double u2 = erand48(ctx->pmsr_xsubi);
+
+		if (u1 < 1e-12)
+			u1 = 1e-12;
+		d += sigma * sqrt(-2.0 * log(u1)) * cos(2.0 * M_PI * u2);
+	}
+	if (ctx->pmsr_nlos_prob > 0.0 &&
+	    erand48(ctx->pmsr_xsubi) < ctx->pmsr_nlos_prob) {
+		double u = erand48(ctx->pmsr_xsubi);
+
+		if (u < 1e-12)
+			u = 1e-12;
+		d += -ctx->pmsr_nlos_bias_m * log(u);
+	}
+	return d < 0.0 ? 0.0 : d;
+}
+
+/*
  * Answer an FTM peer-measurement (PMSR) request from station geometry.
  *
  * The kernel sends HWSIM_CMD_START_PMSR with the initiator radio in
@@ -412,7 +489,7 @@ static void hwsim_handle_pmsr_request(struct wmediumd *ctx,
 		struct nlattr *rpeer, *resp, *data, *ftm;
 		struct station *peer_sta;
 		u8 *peer_addr;
-		double dist;
+		double dist, sigma;
 		int64_t rtt_ps;
 
 		if (nla_type(peer) != NL80211_PMSR_ATTR_PEERS)
@@ -430,7 +507,11 @@ static void hwsim_handle_pmsr_request(struct wmediumd *ctx,
 		if (!peer_sta)
 			continue;
 
-		dist = sta_distance(req_sta, peer_sta);
+		sigma = ctx->pmsr_crlb_alpha > 0.0 ?
+			pmsr_crlb_sigma(ctx, req_sta, peer_sta, pa) :
+			ctx->pmsr_sigma_m;
+		dist = pmsr_apply_error(ctx, sta_distance(req_sta, peer_sta),
+					sigma);
 		rtt_ps = (int64_t)(2.0 * dist / SPEED_OF_LIGHT_M_PER_S * 1e12);
 
 		rpeer = nla_nest_start(msg, ++idx);

--- a/wmediumd/wmediumd.h
+++ b/wmediumd/wmediumd.h
@@ -221,6 +221,15 @@ struct wmediumd {
 	int (*get_fading_signal)(struct wmediumd *);
 
 	u8 log_lvl;
+
+	/* PMSR/FTM two-state ranging-error model (configured from the
+	 * environment; all zero by default = exact geometry). */
+	double pmsr_sigma_m;		/* fixed LOS jitter std dev [m] (fallback) */
+	double pmsr_nlos_prob;		/* probability a measurement is NLOS */
+	double pmsr_nlos_bias_m;	/* mean of the exponential NLOS bias [m] */
+	double pmsr_crlb_alpha;		/* >0: derive LOS sigma from the ToA CRLB */
+	double pmsr_brms_ratio;		/* RMS-to-signal bandwidth ratio (B_rms/B) */
+	unsigned short pmsr_xsubi[3];	/* private erand48 state */
 };
 
 struct hwsim_tx_rate {


### PR DESCRIPTION
Hi @ramonfontes 

Following up in #18 

This PR allows perturbation to the reported PMSR/FTM distance so emulated ranging can reflect better the 802.11mc/az behaviour. 

Two-state (LOS/NLOS): a Gaussian LOS jitter plus, with a configurable probability, a positive exponential NLOS bias (reflections only lengthen the path). 

The LOS sigma is either fixed (pmsr_sigma_m) or derived from the ToA CRLB using the request bandwidth and the medium's own SNR (pmsr_crlb_alpha > 0: sigma = alpha*c/(2*pi*B_rms*sqrt(2*SNR))), so it tracks bandwidth and SNR automatically. 

Read from the config-file model section alongside noise_threshold/fading_coefficient; absent = exact geometry.